### PR TITLE
if문 리팩토링

### DIFF
--- a/ch2/offering.py
+++ b/ch2/offering.py
@@ -8,12 +8,27 @@ class Offering:
         self.employee = employee
         self.updated_offering = updated_offering
 
+    def is_date_updated(self):
+        return True
+
+    def is_description_updated(self):
+        return False
+
+    def is_import_info_updated(self):
+        return self.is_date_updated() or self.is_description_updated()
+
+    def should_receive_an_email(self):
+        """
+        직원들은 이메일을 받도록 동의한 경우나
+        중요한 변경된 경우 이메일을 받아야 한다
+        """
+        is_import_info_was_updated = self.is_import_info_updated()
+        is_employee_wantes_updates = self.employee.wants_any_email_updates()
+
+        return is_import_info_was_updated or is_employee_wantes_updates
+
     def update(self):
-        if (
-            self.employee.wants_any_email_updates()
-            or self.updated_offering.is_date_updated()
-            or self.updated_offering.is_description_updated()
-        ):
+        if self.should_receive_an_email():
             return False
         else:
             return True


### PR DESCRIPTION
1. 이메일 발송 로직에서 결정 과적을 분리한다. 전체 의사결정 프로세스를 `should_receive_an_email()` 메소드로 옮긴다.
2. if문의 각 부분을 설명하는 변수를 도입해 복잡성을 단순화한다.
3. 중요한 정보가 갱신되었는지 결정하는 로직을 `Offering` 클래스 내부의 `is_important_info_updated()` 메소드로 캡슐화한다. 이렇게 하면 향후 로직이 변경될 때 한 곳만 변경하면 된다.
4. 리팩토링한 버전에서는 메소드가 무엇을 하는지 훨씬 쉽게 이해할 수 있다. 복잡한 if문을 나눴기 때문에 주석을 잃고 어떻게 작동하는지 이해할 수 있다.