### PR TITLE
대기자 명단 알림 로직을 별도의 클래스로 옮기도록 리팩토링

### DIFF
--- a/ch2/unenroll_employee_from_offering_service.py
+++ b/ch2/unenroll_employee_from_offering_service.py
@@ -2,19 +2,16 @@
 누군가 등록을 취소했을 때 대기자 명단에 있는 모든 직원에게 이메일을 보내는 기능 구현
 """
 
+from ch2.waiting_list_notifier import WaitingListNotifier
+
 
 class UnenrollEmployeeFromOfferingService:
-    def __init__(self, emailer, offerings):
-        self.emailer = emailer
+    # 서비스는 이제 새로운 WaitingListNotifier에 의존한다.
+    def __init__(self, offerings, notifier: WaitingListNotifier):
         self.offerings = offerings
+        self.notifier = notifier
 
     def unenroll(self, enrollment_id):
         offering = self.offerings.get_offering_from(enrollment_id)
-        # 전체 워크플로우에서 등록 취소 프로세스의 끝에 대기자 명단 알림 단계를 추가한다.
-        self.notify_waiting_list(offering)
-
-    # 알림 로직을 구현한다.
-    def notify_waiting_list(self, offering):
-        employees = offering.get_waiting_list()
-        for employee in employees:
-            self.emailer.send_waiting_list_email(offering, employee)
+        # notifier 클래스를 호출한다.
+        self.notifier.notify(offering)

--- a/ch2/waiting_list_notifier.py
+++ b/ch2/waiting_list_notifier.py
@@ -1,0 +1,8 @@
+class WaitingListNotifier:
+    def __init__(self, emailer):
+        self.emailer = emailer  # 새 클래스는 Emailer에 의존한다.
+
+    def notify(self, offering):  # 알림 로직은 이제 새로운 클래스 안에 위치한다.
+        employees = offering.get_waiting_list()
+        for employee in employees:
+            self.emailer.send_waiting_list_email(offering, employee)


### PR DESCRIPTION
1. 기존 구현은 클래스의 복잡성을 증가시키고, 새로운 기능을 독립적으로 테스트하기도 까다로워진다.
2. 새 클래스는 작고, 테스트가 쉽고, 재사용성이 뛰어나다.
3. 새로운 클래스 디자인은 다음과 같다:

```mermaid
flowchart TD
    A[UnenrollEmployeeFromOfferingService<br>직원을 등록 해제하는 로직을 포함] 
    A --> B[OfferingRepository<br>데이터베이스에서 오퍼링을 읽어옴]
    A --> C[WaitingListNotifier<br>대기자 명단을 관리하는 알림 발송]
    C --> D[Emailer<br>이메일 발송에 집중]
```