### PR TITLE
addEmployee 메소드 추가: 빈 자리가 없는 경우 누구도 오퍼링에 추가할 수 없도록 보장, 잔여 허용 인원 추적

### DIFF
--- a/ch3/apps.py
+++ b/ch3/apps.py
@@ -18,11 +18,8 @@ def use_offering_entity():
     employee_that_wants_to_participate = Employee()
 
     # 현재 오퍼링에 빈 자리가 있는가?
-    if offering.get_available_spots() > 0: 
-        # 직원을 오퍼링에 추가한다
-        offering.get_employees().append(employee_that_wants_to_participate)
-        # 잔여 허용 인원을 하나 줄인다
-        offering.set_available_spots(offering.get_available_spots() - 1)
+    if offering.get_available_spots() > 0:
+        offering.add_employee(employee_that_wants_to_participate)
 
 if __name__ == "__main__":
     use_offering_entity()

--- a/ch3/offering.py
+++ b/ch3/offering.py
@@ -15,14 +15,17 @@ class Offering:
         self.max_number_of_attendees = max_number_of_attendees
         self.available_spots = available_spots
 
-    def get_employees(self) -> list:
-        return self.employees
-    
+    def add_employee(self, employee: Employee):
+        if self.available_spots == 0:
+            raise ValueError
+        # 직원을 오퍼링에 추가한다
+        self.employees.append(employee)
+        # 잔여 허용 인원을 하나 줄인다
+        self.available_spots -= 1
+
     def get_available_spots(self) -> int:
         return self.available_spots
-    
-    def set_available_spots(self, available_spots: int) -> None:
-        self.available_spots = available_spots
+
     
 
         


### PR DESCRIPTION
1. 이제 `Offering` 클래스를 사용하는 클라이언트는 오퍼링과 관련된 기능이 어떻게 작동하는지 알 필요가 없고, 직원을 추가해야 할 때는 `add_employee()` 메소드만 호출하면 된다.
2. 이제 `Offering` 클래스는 `get_employees()` 메소드를 제공하지 않기 때문에, 클라이언트가 클래스 내부의 데이터 구조를 제어 없이 다룰 수 없다.