### PR TITLE
검증 전용 클래스 사용

### DIFF
--- a/ch3/add_employee_to_offering_service.py
+++ b/ch3/add_employee_to_offering_service.py
@@ -1,0 +1,27 @@
+from ch3.repository.offering_repository import OfferingRepository
+from ch3.repository.employee_repository import EmployeeRepository
+from ch3. validator import AddEmployeeToOfferingValidator
+
+class AddEmployeeToOfferingService:
+    def __init__(self, offering_repo: OfferingRepository, employee_repo: EmployeeRepository, validator: AddEmployeeToOfferingValidator):
+        self.offerings = offering_repo
+        self.employees = employee_repo
+        self.validator = validator
+
+    def add_employee(self, offering_id: int, employee_id: int):
+        offering = self.offerings.find_by_id(offering_id)
+        employee = self.employees.find_by_id(employee_id)
+
+        # 오퍼링과 직원의 id가 유효한지 검사한다.
+        if not offering or not employee:
+            raise ValueError("offering and employee ids should be valid")
+        
+        # validator를 호출해 비즈니스 측면에서 요청이 유효한지 확인한다.
+        validation = self.validator.validate(offering, employee)
+        # 검증에 실패하면 예외를 던져 클라이언트가 처리하게 한다.
+        if not validation:
+            raise ValueError()
+        
+        # 직원을 오퍼링에 추가한다.
+        offering.add_employee(employee)
+

--- a/ch3/offering.py
+++ b/ch3/offering.py
@@ -25,6 +25,18 @@ class Offering:
 
     def get_available_spots(self) -> int:
         return self.available_spots
+    
+    def has_available_spots(self):
+        return self.get_available_spots() > 0
+    
+    def get_training(self):
+        return self.training
+    
+    def is_employee_registered(self, employee: Employee):
+        for e in self.employees:
+            if e == employee:
+                return True
+        return False
 
     
 

--- a/ch3/repository/employee_repository.py
+++ b/ch3/repository/employee_repository.py
@@ -1,0 +1,9 @@
+class EmployeeRepository:
+    def __init__(self):
+        self.repository = []
+
+    def find_by_id(self, id: int):
+        for offering in self.repository:
+            if offering == id:
+                return offering
+        return None

--- a/ch3/repository/offering_repository.py
+++ b/ch3/repository/offering_repository.py
@@ -1,0 +1,16 @@
+from typing import Optional
+from ch3.offering import Offering
+
+class OfferingRepository:
+    def __init__(self):
+        self.repository = []
+
+    def find_by_id(self, id: int) -> Optional[Offering]:
+        offering: Offering
+        for offering in self.repository:
+            if offering.id == id:
+                return offering
+        return None
+    
+    def add_employee(self, employee):
+        self.repository.append(employee)

--- a/ch3/repository/training_repository.py
+++ b/ch3/repository/training_repository.py
@@ -1,0 +1,10 @@
+import random
+from ch3.employee import Employee
+from ch3.training import Training
+
+class TrainingRepository:
+    def __init__(self):
+        self.repository = []
+
+    def count_participations(self, employee: Employee, training: Training) -> int:
+        return random.randint(0, 5)

--- a/ch3/validator.py
+++ b/ch3/validator.py
@@ -1,0 +1,24 @@
+from ch3.repository.training_repository import TrainingRepository
+from ch3.offering import Offering
+from ch3.employee import Employee
+
+class AddEmployeeToOfferingValidator:
+    def __init__(self, trainings: TrainingRepository):
+        self.validation_result = []
+        self.trainings = trainings
+
+    def validate(self, offering: Offering, employee: Employee):
+        # 오퍼링에 빈 자리가 있어야 한다.
+        if not offering.has_available_spots():
+            self.validation_result.add("Offering has no available spots")
+
+        # 참가자가 이 과정을 3번 이상 수강했으면 안 된다.
+        times_participant_took_the_training = self.trainings.count_participations(employee, offering.get_training())
+        if times_participant_took_the_training >= 3:
+            self.validation_result.add("Participant can't ttake the training again")
+
+        # 참가자가 이 오퍼링에 이미 등록되어 있으면 안 된다.
+        if offering.is_employee_registered():
+            self.validation_result.add("Participant already in this offering")
+
+        return self.validation_result


### PR DESCRIPTION
`validate` 메소드는 검증기가 식별한 오류들의 목록을 저장한다. 서비스는 그 후 오류가 잇는지 묻고, 오류에 대해 어떤 일을 할지 결정한다.
이 코드에서 중요한 점은 서비스가 동작을 조율하며 유효하지 않은 요청이 진행되지 않도록 막는다는 것이다. 이를 통해 오퍼링의 상태를 항상 일관성 있게 유지할 수 있다.
이는 클라이언트가 `add_employee()`를 직접 호출할 수 없고, 서비스만 이 함수를 호출할 수 있어야 한다.