### PR TITLE
클라이언트가 직접 Enrollment를 변경할 수 없도록 리팩토링

### DIFF
--- a/ch3/add_employee_to_offering_service.py
+++ b/ch3/add_employee_to_offering_service.py
@@ -23,5 +23,5 @@ class AddEmployeeToOfferingService:
             raise ValueError()
         
         # 직원을 오퍼링에 추가한다.
-        offering.add_employee(employee)
+        offering.enroll(employee)
 

--- a/ch3/apps.py
+++ b/ch3/apps.py
@@ -19,7 +19,7 @@ def use_offering_entity():
 
     # 현재 오퍼링에 빈 자리가 있는가?
     if offering.get_available_spots() > 0:
-        offering.add_employee(employee_that_wants_to_participate)
+        offering.enroll(employee_that_wants_to_participate)
 
 if __name__ == "__main__":
     use_offering_entity()

--- a/ch3/enrollment.py
+++ b/ch3/enrollment.py
@@ -1,0 +1,17 @@
+"""
+Enrollment 엔터티는 직원, 등록 날짜, 등록 상태, 등록 취소를 한 경우 취소 날짜를 포함한다.
+Enrollment 클래스는 등록에 대한 모든 정보를 저장한다. 또 등록을 취소하고 취소 날짜를 설정하는 cancel 메소드를 제공한다.
+"""
+from typing import Optional
+from ch3.employee import Employee
+
+class Enrollment:
+    def __init__(self, employee: Employee, date_of_enrollment: str):
+        self.employee = employee
+        self.date_of_enrollment = date_of_enrollment
+        self.status = True
+        self.date_of_cancellation = None
+
+    def cancel(self, date_of_cancellation: str):
+        self.status = False
+        self.date_of_cancellation = date_of_cancellation

--- a/ch3/offering.py
+++ b/ch3/offering.py
@@ -2,26 +2,47 @@
 Offering 클래스에는 날짜, 교육 과정에 참석하는 직원 목록, 최대 참석자 수, 
 텍스트 필드(관리자가 강의실 위치, 줌 링크 등의 정보를 입력할 수 있음)가 있다.
 """
+from typing import Optional
+from datetime import datetime
 from ch3.employee import Employee
 from ch3.training import Training
+from ch3.enrollment import Enrollment
 
 
 class Offering:
-    def __init__(self, id, training: Training, date: str, employees: list, max_number_of_attendees: int, available_spots: int):
+    def __init__(self, id, training: Training, date: str, enrollments: list[Enrollment], max_number_of_attendees: int, available_spots: int):
         self.id = id
         self.training = training
         self.date = date
-        self.employees = employees
+        self.enrollments = enrollments # 직원 리스트를 등록의 리스트로 변경한다.
         self.max_number_of_attendees = max_number_of_attendees
         self.available_spots = available_spots
 
-    def add_employee(self, employee: Employee):
+    # 등록을 생성하고 오퍼링의 상태와 등록의 상태가 일관성 있게 한다.
+    def enroll(self, employee: Employee):
         if self.available_spots == 0:
             raise ValueError
         # 직원을 오퍼링에 추가한다
-        self.employees.append(employee)
+        now = datetime.now()
+        self.enrollments.append(Enrollment(employee, now))
         # 잔여 허용 인원을 하나 줄인다
         self.available_spots -= 1
+
+    # 등록을 취소하고 전체 애그리게이트의 일관성을 보장한다.
+    def cancel(self, employee: Employee):
+        enrollment_to_cancel = self.find_enrollment_of(employee)
+        if not enrollment_to_cancel:
+            raise ValueError()
+        
+        now = datetime.now()
+        enrollment_to_cancel.cancel(now)
+        self.available_spots += 1
+
+    def find_enrollment_of(self, employee: Employee) -> Optional[Enrollment]:
+        for enrollment in self.enrollments:
+            if enrollment == employee:
+                return enrollment
+        return None
 
     def get_available_spots(self) -> int:
         return self.available_spots


### PR DESCRIPTION
`Offering` 애그리게이트 루트는 전체 애그리게이트의 일관성을 보장한다.
오퍼링이나 내부 도메인 객체에 대한 모든 작업은 반드시 애그리게이트 루트를 통해 이루어져야 하고, 디자인은 내부 도메인 객체 수정이 불가능하도록 이루어져야 한다.
등록을 췩소하는 작업이 나중에 별도의 서비스로 분리된다면, 서비스는 취소가 유효한지 확인한 후 오퍼링에 등록을 추가할 때와 마찬가지 방식으로 애그리게이트에게 취소를 전달해 `Offering`에 반영하도록 할 것이다.