### PR TITLE
Fix/ch4.3.1

### DIFF
--- a/ch4/email_sender.py
+++ b/ch4/email_sender.py
@@ -1,9 +1,13 @@
 from ch4.message import Message
+from ch4.user_preferences import UserPreferences
 
 
 class EmailSender:
-    def __init__(self):
-        pass
+    def __init__(self, user_pref: UserPreferences):
+        self.user_pref = user_pref
+
+    def is_user_prefer_to_send_via_email(self, email):
+        return self.user_pref.send_via_email(email)
 
     def send_message(self, message: Message):
         return message

--- a/ch4/message_bot.py
+++ b/ch4/message_bot.py
@@ -1,0 +1,13 @@
+from ch4.bot.bot import Bot
+from ch4.user_directory import UserDirectory
+from ch4.message import Message
+
+
+class MessageBot:
+    def __init__(self, bot: Bot, user_directory: UserDirectory):
+        self.bot = bot
+        self.user_directory = user_directory
+
+    def send(self, msg: Message):
+        user_id = self.user_directory.get_account(msg.get_email())
+        self.bot.send_private_message(user_id, msg.get_body_in_markdown())

--- a/ch4/message_sender.py
+++ b/ch4/message_sender.py
@@ -1,7 +1,6 @@
 from ch4.message import Message
 from ch4.message_bot import MessageBot
 from ch4.email_sender import EmailSender
-from ch4.user_preferences import UserPreferences
 from ch4.repository.message_repository import MessageRepository
 
 
@@ -11,12 +10,10 @@ class MessageSender:
         message_bot: MessageBot,
         repository: MessageRepository,
         email_sender: EmailSender,
-        user_prefs: UserPreferences,
     ):
         self.message_bot = message_bot
         self.repository = repository
         self.email_sender = email_sender
-        self.user_prefs = user_prefs
 
     def send_messages(self) -> None:
         messages_to_be_sent = self.repository.get_messages_to_be_sent()
@@ -24,7 +21,9 @@ class MessageSender:
         # 송신해야 하는 모든 메시지에 대해
         for message_to_be_sent in messages_to_be_sent:
             self.message_bot.send(message_to_be_sent)
-            if self.user_prefs.send_via_email(message_to_be_sent.get_email()):
+            if self.email_sender.is_user_prefer_to_send_via_email(
+                message_to_be_sent.get_email()
+            ):
                 self.email_sender.send_message(message_to_be_sent)
 
             # 메시지를 전송 완료로 표시한다.

--- a/ch4/message_sender.py
+++ b/ch4/message_sender.py
@@ -1,6 +1,5 @@
-from ch4.bot.bot import Bot
 from ch4.message import Message
-from ch4.user_directory import UserDirectory
+from ch4.message_bot import MessageBot
 from ch4.email_sender import EmailSender
 from ch4.user_preferences import UserPreferences
 from ch4.repository.message_repository import MessageRepository
@@ -9,16 +8,13 @@ from ch4.repository.message_repository import MessageRepository
 class MessageSender:
     def __init__(
         self,
-        bot: Bot,
-        user_directory: UserDirectory,
+        message_bot: MessageBot,
         repository: MessageRepository,
         email_sender: EmailSender,
         user_prefs: UserPreferences,
     ):
-        self.bot = bot
-        self.user_directory = user_directory
+        self.message_bot = message_bot
         self.repository = repository
-        # 새로운 의존성을 추가한다.
         self.email_sender = email_sender
         self.user_prefs = user_prefs
 
@@ -27,14 +23,7 @@ class MessageSender:
         message_to_be_sent: Message
         # 송신해야 하는 모든 메시지에 대해
         for message_to_be_sent in messages_to_be_sent:
-            # 이메일에서 사용자의 id를 가져온다.
-            user_id = self.user_directory.get_account(message_to_be_sent.get_email())
-            # 봇을 통해 메시지를 전송한다.
-            self.bot.send_private_message(
-                id=user_id,
-                message=message_to_be_sent.get_body_in_markdown(),
-            )
-            # 두가지 새 의존성을 사용해 메시지 복사본을 사용자에게 이메일로 보낼지 결정한다.
+            self.message_bot.send(message_to_be_sent)
             if self.user_prefs.send_via_email(message_to_be_sent.get_email()):
                 self.email_sender.send_message(message_to_be_sent)
 


### PR DESCRIPTION
새 기능 추거로 인해 `MessageSender` 클래스가 5개의 클래스에 의존하게 되었다. 이 클래스를 분리하고 일부 의존성을 이동시켜 제어권을 되찾아야 한다.
의존성을 그룹화하는 래퍼 클래스를 만들어서 이 문제를 해결한다. `MessageBot` 클래스는 `Bot`과 `UserDirectory`를 대신 상속받아 클라이언트 결합도가 낮아진다. 

의존성 그룹화 전 `MessageSender`의 모습:

```mermaid
classDiagram
    MessageSender <|-- UserDirectory
    MessageSender <|-- Bot
    MessageSender <|-- MessageRepository
    MessageSender <|-- EmailSender
    MessageSender <|-- UserPreferences
    class MessageSender{}
    class UserDirectory {}
    class Bot {}
    class MessageRepository {}
    class EmailSender {}
    class UserPreferences {}
```

의존성 그룹화 후 `MessageSender`의 모습:

```mermaid
classDiagram
    MessageSender <|-- MessageBot
    MessageSender <|-- MessageRepository
    MessageSender <|-- EmailSender
    MessageBot <|-- UserDirectory
    MessageBot <|-- Bot
    EmailSender <|-- UserPreferences
    class MessageSender{}
    class UserDirectory {}
    class MessageBot {}
    class MessageRepository {}
    class EmailSender {}
    class UserPreferences {}
```