### PR TITLE
하위호환성을 지원하며 단순한 인터페이스를 제공할 수 있는 api 초안 구현

### DIFF
--- a/ch7/notification.py
+++ b/ch7/notification.py
@@ -1,0 +1,3 @@
+class Notification:
+    def __init__(self):
+        pass

--- a/ch7/notification_api.py
+++ b/ch7/notification_api.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from ch7.notification import Notification
+from ch7.types import Medium, DispatchTime
+
+class NotificationAPI(ABC):
+    @abstractmethod
+    def create_notification(self, message: str, supported_medium: list[Medium], times: list[DispatchTime]) -> Notification:
+        pass
+
+    def add_participant(self, notification_id: int, participant_email: str) -> None:
+        pass
+
+    def remove_participant(self, notification_id: int, participant_email: str) -> None:
+        pass

--- a/ch7/types.py
+++ b/ch7/types.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class Medium(Enum):
+    EMAIL = "EMAIL"
+    CHAT = "CHAT"
+    WHATSAPP = "WHATSAPP"
+
+
+class DispatchTime(Enum):
+    RIGHT_NOW = "RIGHT_NOW"
+    ONE_WEEK_BEFORE = "ONE_WEEK_BEFORE"
+    DAY_BEFORE = "DAY_BEFORE"
+    ONE_HOUR_BEFORE = "ONE_HOUR_BEFORE"


### PR DESCRIPTION
1. `create_notification`은 클라이언트가 새로운 알림을 생성할 수 있는 방법을 제공한다. 이 API는 메시지 내용, 지원할 매체, 전송 시점이 필요하다.
2. `add_participant`는 클라이언트가 알림에 참가자 목록을 추가할 수 있는 방법을 제공한다. 클라이언트는 `create_notification`에서 반환받은 알림 id와 이메일 목록을 API에 전달한다. 새 사용자를 추가하면서 이 API를 원하는 만큼 호출할 수 있다.
3. `remove_participant`는 특정 알림에서 참가자를 제거하는 방법을 제공한다.